### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Code Review
-        uses: freeedcom/ai-codereviewer@main
+        uses: freeedcom/ai-codereviewer@a9a064dfa1db8c83f40ef63f6e247fa09c935ed6 # main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- add explicit top-level `permissions: read-all` to workflows that relied on GitHub defaults
- pin remote GitHub Actions/reusable workflow refs to full commit SHAs
- keep the previous tag or branch ref as a YAML comment where the line had no existing comment
